### PR TITLE
Fix/date time

### DIFF
--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -150,7 +150,9 @@ class MeetingsController < ApplicationController
     puts "input datetime: #{datetime_str}"
     # Parse the datetime string to a DateTime object
     datetime = DateTime.parse(datetime_str)
-    formatted = datetime.strftime("%Y-%m-%dT%H:%M:%S%Z")
+    # Format the DateTime object to the ISO8601 format
+    # as required by Zoho CRM
+    formatted = datetime.iso8601
     puts "formatted datetime: #{formatted}"
     formatted
   end

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -19,8 +19,8 @@ class MeetingsController < ApplicationController
       # we get session_id, sumary, report_url, start_time, end_time and title
       session_id = params[:session_id]
       title = params[:title]
-      start_time = params[:start_time]
-      end_time = params[:end_time]
+      start_time = format_datetime(params[:start_time])
+      end_time = format_datetime(params[:end_time])
       summary = params[:summary]
       report_url = params[:report_url]
       puts "Session ID: #{session_id}"
@@ -144,5 +144,14 @@ class MeetingsController < ApplicationController
       puts "Error came from Zoho: #{response.code} - #{response.message}"
       nil
     end
+  end
+
+  def format_datetime(datetime_str)
+    puts "input datetime: #{datetime_str}"
+    # Parse the datetime string to a DateTime object
+    datetime = DateTime.parse(datetime_str)
+    formatted = datetime.strftime("%Y-%m-%dT%H:%M:%S%Z")
+    puts "formatted datetime: #{formatted}"
+    formatted
   end
 end

--- a/app/controllers/meetings_controller.rb
+++ b/app/controllers/meetings_controller.rb
@@ -19,8 +19,8 @@ class MeetingsController < ApplicationController
       # we get session_id, sumary, report_url, start_time, end_time and title
       session_id = params[:session_id]
       title = params[:title]
-      start_time = format_datetime(params[:start_time])
-      end_time = format_datetime(params[:end_time])
+      start_time = params[:start_time]
+      end_time = params[:end_time]
       summary = params[:summary]
       report_url = params[:report_url]
       puts "Session ID: #{session_id}"
@@ -62,8 +62,8 @@ class MeetingsController < ApplicationController
             summary: params[:summary],
             action_items: params[:action_items],
             report_url: params[:report_url],
-            start_time: params[:start_time],
-            end_time: params[:end_time]
+            start_time: "#{format_datetime(params[:start_time])}",
+            end_time: "#{format_datetime(params[:end_time])}"
           }
         ]
 


### PR DESCRIPTION
# Fix Bug:
- Dates were not correctly formatted as required by Zoho CRM:
  - Date/Timestring
    Accepts date and time in **yyyy-MM-ddTHH:mm:ss±HH:mm** format. 
    **Example:** "Date_Time": "2017-08-16T14:32:23+05:30".  
    Date_Time is in the ISO8601 format and the time zone is the current user's time zone.
    `